### PR TITLE
typography: LinkText and LinkButton Components [RD-12]

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ButtonProps, getButtonClassNames } from './ButtonConfig';
+
+export default function Button({
+	variant = 'primary',
+	isLoading = false,
+	isDisabled = false,
+	isSelected = false,
+	children,
+	onClick,
+	type = 'button',
+	ariaLabel,
+	style,
+	title
+}: ButtonProps) {
+	const isTrulyDisabled = isDisabled || isLoading;
+
+	return (
+		<button
+			type={type}
+			className={getButtonClassNames(variant, isLoading, isSelected)}
+			onClick={onClick}
+			disabled={isTrulyDisabled}
+			aria-disabled={isTrulyDisabled} // Accessibility: screen readers will recognize disabled state
+			aria-busy={isLoading} // Accessibility: notifies when button is loading
+			aria-label={ariaLabel} // Accessibility: label for buttons without visible text
+			style={style}
+			title={title}
+			tabIndex={isTrulyDisabled ? -1 : undefined}
+		>
+			{isLoading ? (
+				<span className="sr-only">Loading</span> // Screen readers only text
+			) : (
+				children
+			)}
+		</button>
+	);
+}

--- a/src/components/Button/ButtonConfig.ts
+++ b/src/components/Button/ButtonConfig.ts
@@ -1,0 +1,52 @@
+// Available button variants
+export const buttonVariants = [
+	'primary',
+	'outline',
+	'light',
+	'success',
+	'error',
+	'toggle',
+	'copy'
+] as const;
+
+export type Variant = (typeof buttonVariants)[number];
+
+// Props for the Button component
+export type ButtonProps = {
+	variant?: Variant;
+	isLoading?: boolean;
+	isDisabled?: boolean;
+	isSelected?: boolean;
+	children: React.ReactNode;
+	onClick?: () => void;
+	type?: 'button' | 'submit' | 'reset';
+	ariaLabel?: string;
+	style?: React.CSSProperties;
+	title?: string;
+};
+
+// Generate className based on button props
+export function getButtonClassNames(
+	variant: Variant = 'primary',
+	isLoading: boolean = false,
+	isSelected: boolean = false
+): string {
+	// Special case: 'copy' button has its own unique style
+	if (variant === 'copy') {
+		return 'copy-button';
+	}
+
+	const classes = ['btn', variant];
+
+	// Toggle button - if selected, add 'active' class
+	if (variant === 'toggle' && isSelected) {
+		classes.push('active');
+	}
+
+	// Loading state - add 'btn-loading' class
+	if (isLoading) {
+		classes.push('loading');
+	}
+
+	return classes.join(' ').trim();
+}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,2 @@
+export { default as Button } from './Button';
+export { buttonVariants } from './ButtonConfig';

--- a/src/components/Typography/LinkButton.tsx
+++ b/src/components/Typography/LinkButton.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Link from 'next/link';
+import clsx from 'clsx';
+import { Variant, getButtonClassNames } from '@/components/Button/ButtonConfig';
+
+type LinkButtonProps = {
+	href: string;
+	buttonType?: Variant;
+	children: React.ReactNode;
+	className?: string;
+	isDisabled?: boolean;
+	target?: '_blank' | '_self' | '_parent' | '_top';
+	rel?: string;
+	ariaLabel?: string;
+};
+
+export default function LinkButton({
+	href,
+	buttonType = 'primary',
+	children,
+	className = '',
+	isDisabled = false,
+	target,
+	rel,
+	ariaLabel
+}: LinkButtonProps) {
+	const isExternal = href.startsWith('http');
+
+	const commonClassNames = clsx(
+		'button',
+		'link-button',
+		getButtonClassNames(buttonType),
+		className
+	);
+
+	if (isDisabled) {
+		return (
+			<span
+				className={clsx('button', 'link-button-disabled', getButtonClassNames(buttonType), className)}
+				aria-disabled="true"
+			>
+				{children}
+			</span>
+		);
+	}
+
+	if (isExternal) {
+		return (
+			<a
+				href={href}
+				className={commonClassNames}
+				target={target || '_blank'}
+				rel={rel || 'noopener noreferrer'}
+				aria-label={ariaLabel}
+			>
+				{children}
+			</a>
+		);
+	}
+
+	return (
+		<Link
+			href={href}
+			className={commonClassNames}
+			aria-label={ariaLabel}
+		>
+			{children}
+		</Link>
+	);
+}

--- a/src/components/Typography/LinkText.tsx
+++ b/src/components/Typography/LinkText.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import clsx from 'clsx';
+
+type LinkTextProps = {
+	href: string;
+	children: React.ReactNode;
+	className?: string;
+	isDisabled?: boolean;
+	target?: '_blank' | '_self' | '_parent' | '_top';
+	rel?: string;
+	noUnderline?: boolean;
+};
+
+export default function LinkText({
+	href,
+	children,
+	className = '',
+	isDisabled = false,
+	target,
+	rel,
+	noUnderline = false
+}: LinkTextProps) {
+	const isExternal = href.startsWith('http');
+
+	if (isDisabled) {
+		return (
+			<span
+				className={clsx('link-disabled', className)}
+				aria-disabled="true"
+			>
+				{children}
+			</span>
+		);
+	}
+
+	if (isExternal) {
+		return (
+			<a
+				href={href}
+				className={clsx(
+					'link',
+					noUnderline && 'link-no-underline',
+					className
+				)}
+				target={target || '_blank'}
+				rel={rel || 'noopener noreferrer'}
+			>
+				{children}
+			</a>
+		);
+	}
+
+	return (
+		<Link
+			href={href}
+			className={clsx(
+				'link',
+				noUnderline && 'link-no-underline',
+				className
+			)}
+		>
+			{children}
+		</Link>
+	);
+}

--- a/src/components/Typography/index.ts
+++ b/src/components/Typography/index.ts
@@ -16,4 +16,6 @@ export { default as TextNote } from './TextNote';
 export { default as BoldText } from './BoldText';
 export { default as ItalicText } from './ItalicText';
 export { default as UnderlineText } from './UnderlineText';
+export { default as LinkText } from './LinkText';
+export { default as LinkButton } from './LinkButton';
 export { default as Divider } from './Divider';

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from 'next-intl';
 import PageLayout from '@/components/PageLayout';
-import { Heading2, Paragraph } from '@/components/Typography';
+import { Heading2, Paragraph, LinkButton } from '@/components/Typography';
 
 export default function HomePage() {
 	const t = useTranslations('HomePage');
@@ -9,7 +9,7 @@ export default function HomePage() {
 		<PageLayout>
 			<Heading2>{t('title')}</Heading2>
 			<Paragraph>{t('description')}</Paragraph>
-			<button>{t('button')}</button>
+			<LinkButton href="#">{t('button')}</LinkButton>
 		</PageLayout>
 	);
 }

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -1,0 +1,164 @@
+/* Buttons */
+.btn,
+.link-button {
+	font-family: var(--font-body);
+	padding: 0.6rem 1.2rem;
+	font-size: 1rem;
+	border-radius: 4px;
+	border: none;
+	cursor: pointer;
+	transition:
+		background-color 0.2s ease,
+		border-color 0.2s ease,
+		color 0.2s ease;
+	display: inline-block;
+
+	/* Primary */
+	&.primary {
+		background: var(--color-btn-primary);
+		color: var(--color-white);
+		border: 2px solid var(--color-btn-primary);
+
+		&:hover,
+		&:focus {
+			background: var(--color-btn-primary-hover);
+			border: 2px solid var(--color-btn-primary-hover);
+		}
+	}
+
+	/* Outline */
+	&.outline {
+		background: transparent;
+		color: var(--color-btn-outline);
+		border: 2px solid var(--color-btn-outline);
+
+		&:hover,
+		&:focus {
+			background: var(--color-btn-outline-background-hover);
+			border-color: var(--color-btn-outline-hover);
+			color: var(--color-btn-outline-hover);
+		}
+	}
+
+	/* Primary Light */
+	&.light {
+		background-color: var(--color-btn-primary-light);
+		color: var(--color-white);
+		border: 2px solid var(--color-btn-light);
+
+		&:hover,
+		&:focus {
+			background-color: var(--color-btn-primary-light-hover);
+			border: 2px solid var(--color-btn-light-hover);
+		}
+	}
+
+	&.toggle {
+		padding: 0.4rem 0.8rem;
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-main);
+		border-radius: 0.25rem;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&.active,
+		&.selected {
+			background: var(--color-link);
+			color: var(--color-white);
+			border-color: var(--color-link);
+		}
+	}
+
+	/* Success */
+	&.success {
+		background-color: var(--color-btn-success);
+		color: var(--color-white);
+		border: 2px solid var(--color-btn-success);
+
+		&:hover,
+		&:focus {
+			background-color: var(--color-btn-success-hover);
+			border: 2px solid var(--color-btn-success-hover);
+		}
+	}
+
+	/* Error */
+	&.error {
+		background-color: var(--color-btn-error);
+		color: var(--color-white);
+		border: 2px solid var(--color-btn-error);
+
+		&:hover,
+		&:focus {
+			background-color: var(--color-btn-error-hover);
+			border: 2px solid var(--color-btn-error-hover);
+		}
+	}
+
+	/* Disabled */
+	&[disabled]:not(.loading),
+	&[aria-disabled='true']:not(.loading),
+	&-disabled {
+		background: var(--color-btn-disabled);
+		color: var(--color-white);
+		border: 2px solid var(--color-btn-disabled);
+		cursor: not-allowed;
+		opacity: 0.6;
+		pointer-events: none;
+	}
+
+	&.loading {
+		position: relative;
+		pointer-events: none;
+		opacity: 0.8;
+
+		&::after {
+			content: '';
+			width: 1rem;
+			height: 1rem;
+			display: inline-block;
+			border-radius: 50%;
+			border: 2px solid transparent;
+			border-top-color: var(--color-white);
+			animation: spin 1s linear infinite;
+			margin-top: -0.5rem;
+			margin-left: -0.5rem;
+		}
+
+		color: transparent !important;
+	}
+}
+
+.copy-button {
+	display: inline-flex;
+	padding: 0.25rem 0.5rem;
+	font-size: 0.75rem;
+	font-family: var(--font-body);
+	background-color: var(--color-bg-muted);
+	color: var(--color-text-default);
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+	align-self: center;
+	align-items: center;
+	gap: 0.25rem;
+
+	&:hover {
+		background-color: var(--color-bg-secondary);
+	}
+
+	&:active {
+		opacity: 0.9;
+	}
+
+	svg {
+		width: 1rem;
+	}
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -2,6 +2,7 @@
 @use './reset';
 @use './mixins' as *;
 @use './typography.scss';
+@use './button.scss';
 
 html {
 	scroll-behavior: smooth;

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -90,6 +90,45 @@ p {
 }
 
 // -----------------------------------------
+// Links
+// -----------------------------------------
+.link {
+	color: var(--color-link);
+	text-decoration: none;
+	border-bottom: 1px dashed var(--color-link);
+	transition: color 0.3s;
+	cursor: pointer;
+
+	&:hover,
+	&:focus {
+		color: var(--color-link-hover);
+		border-bottom: 1px solid var(--color-link-hover);
+	}
+
+	&-no-underline {
+		text-decoration: none;
+		border-bottom: none;
+
+		&:hover {
+			color: inherit;
+			text-decoration: none;
+			border-bottom: none;
+		}
+	}
+}
+
+.link-disabled {
+	color: var(--color-text-muted);
+	text-decoration: none;
+	cursor: not-allowed;
+}
+
+// Link as button
+// See @components/Button/Button.scss
+// Use .btn for button look
+// Add style with: .primary / .outline / .light / .success / .error / .disabled
+
+// -----------------------------------------
 // Inline text formatting
 // -----------------------------------------
 strong,


### PR DESCRIPTION
### Summary  
Initial implementation of linked text and interactive button components for the Typography System and UI System.  
These components provide accessible, styled, and semantically appropriate elements for both navigation and user actions.

### What's Included  
- ✅ `LinkText` – inline text link, styled via typography system  
- ✅ `LinkButton` – visually styled as a button, built with `<Link>` / `<a>`  
- ✅ `Button` – core UI action component, supports variants and states

### Notes  
- `LinkText` and `LinkButton` are located inside `typography`  
- `Button` is located in the UI system folder  
- All components share styles via `getButtonClassNames()`  
- Centralized styling via `typography.scss` and `button.scss`  
- `LinkButton` supports:  
  - `aria-label`  
  - fallback to `<span>` when disabled  
  - default `buttonType = 'primary'`  
- All components support `className`, `id`, `children`  
- RTL-compatible; no SCSS Modules are used

### Jira  
[RD-12 – LinkText and LinkButton Components](https://ravit-dabush.atlassian.net/browse/RD-12)

### Checklist  
- [x] Folder and file structure created for all components  
- [x] Components render correct semantic tags (`<a>`, `<Link>`, `<button>`)  
- [x] Shared classNames and styling across button types  
- [x] Accessibility attributes implemented (`aria-*`)  
- [x] Connected to centralized SCSS (`typography.scss`, `button.scss`)  
- [x] Ready for integration with StyleGuide  
